### PR TITLE
Resolve heap-references for getByKey results

### DIFF
--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
@@ -46,6 +46,10 @@ public class HeapFunctions {
         }
     }
 
+    private static Object resolveReference(Object value) {
+        return value instanceof IObject ? HeapReference.valueOf((IObject)value) : value;
+    }
+
     @SuppressWarnings("unused")
     public static Object getByKey(Object r, String key) {
         HeapReference ref = ensureHeapReference(r);
@@ -56,7 +60,7 @@ public class HeapFunctions {
         try {
             for (Map.Entry<IObject, IObject> entry : CollectionExtractionUtils.extractMap(ref.getIObject())) {
                 if (key.equals(toString(entry.getKey()))) {
-                    return entry.getValue();
+                    return resolveReference(entry.getValue());
                 }
             }
             return null;
@@ -131,12 +135,7 @@ public class HeapFunctions {
             return null;
         }
 
-        Object value = IObjectMethods.resolveSimpleValue(ref.getIObject(), fieldName);
-        if (value instanceof IObject) {
-            return HeapReference.valueOf((IObject)value);
-        } else {
-            return value;
-        }
+        return resolveReference(IObjectMethods.resolveSimpleValue(ref.getIObject(), fieldName));
     }
 
     @SuppressWarnings("unused")

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AbstractQueriesTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AbstractQueriesTests.java
@@ -1,0 +1,103 @@
+package com.github.vlsi.mat.tests.calcite;
+
+import com.github.vlsi.mat.calcite.CalciteDataSource;
+import com.google.common.base.Joiner;
+import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.snapshot.ISnapshot;
+import org.eclipse.mat.snapshot.SnapshotFactory;
+import org.eclipse.mat.util.VoidProgressListener;
+import org.junit.Assert;
+
+import java.io.File;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class AbstractQueriesTests {
+
+    protected abstract ISnapshot getSnapshot();
+
+    protected static ISnapshot openSnapshot(File heapDump) throws SnapshotException {
+        System.out.println("exists = " + heapDump.exists() + ", file = " + heapDump.getAbsolutePath());
+        return SnapshotFactory.openSnapshot(heapDump, new VoidProgressListener());
+    }
+
+    public static void closeSnapshot(ISnapshot snapshot) {
+        SnapshotFactory.dispose(snapshot);
+    }
+
+    protected void returnsInOrder(String sql, String ... expected) throws SQLException {
+        String[] actuals = new String[0];
+        try {
+            actuals = executeToCSV(sql).toArray(actuals);
+        } catch (SQLException e) {
+            e.printStackTrace(); // tycho-surefire-plugin forces trimStackTrace=true
+        }
+        System.out.println("Arrays.toString(expected) = " + Arrays.toString(expected));
+        System.out.println("Arrays.toString(actuals) = " + Arrays.toString(actuals));
+        Assert.assertArrayEquals(sql, nnl(expected), nnl(actuals));
+    }
+
+    protected List<String> executeToCSV(String sql) throws SQLException {
+        List<String> res = new ArrayList<String>();
+        System.out.println("sql = " + sql);
+        try (Connection con = CalciteDataSource.getConnection(getSnapshot())) {
+            PreparedStatement ps = con.prepareStatement(sql);
+            ResultSet rs = ps.executeQuery();
+            ResultSetMetaData md = rs.getMetaData();
+            Joiner joiner = Joiner.on('|');
+            List<String> row = new ArrayList<String>();
+            final int columnCount = md.getColumnCount();
+            for (int i = 1; i <= columnCount; i++) {
+                row.add(md.getColumnName(i));
+            }
+            res.add(joiner.join(row));
+            while(rs.next()) {
+                row.clear();
+                for (int i = 1; i <= columnCount; i++) {
+                    row.add(String.valueOf(rs.getObject(i)));
+                }
+                res.add(joiner.join(row));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace(); // tycho-surefire-plugin forces trimStackTrace=true
+            throw e;
+        }
+        return res;
+    }
+
+    protected void execute(String sql, int limit) throws SQLException {
+        System.out.println("sql = " + sql);
+
+        try (Connection con = CalciteDataSource.getConnection(getSnapshot())) {
+            PreparedStatement ps = null;
+            ResultSet rs = null;
+            ps = con.prepareStatement(sql);
+            rs = ps.executeQuery();
+            ResultSetMetaData md = rs.getMetaData();
+            for (int j = 0; rs.next() && j < limit; j++) {
+                for (int i = 1; i <= md.getColumnCount(); i++) {
+                    System.out.println(md.getColumnName(i) + ": " + String.valueOf(rs.getObject(i)));
+                }
+                System.out.println();
+            }
+        } catch (SQLException e) {
+            e.printStackTrace(); // tycho-surefire-plugin forces trimStackTrace=true
+            throw e;
+        }
+    }
+
+    protected static String nnl(String text) {
+        return text.replace("\r\n", "\n").replace("\r", "\n");
+    }
+
+    protected static Object[] nnl(Object[] array) {
+        for (int i = 0; i<array.length; i++) {
+            if (array[i] instanceof String) {
+                array[i] = nnl((String)array[i]);
+            }
+        }
+        return array;
+    }
+}

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AllTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AllTests.java
@@ -5,7 +5,8 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-        QueryTest.class
+        BasicQueriesTests.class,
+        GetByKeyTests.class
 })
 public class AllTests {
 }

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/GetByKeyTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/GetByKeyTests.java
@@ -1,0 +1,27 @@
+package com.github.vlsi.mat.tests.calcite;
+
+import org.junit.Test;
+import java.sql.SQLException;
+
+public class GetByKeyTests extends SampleHeapDumpTests {
+    @Test
+    public void testHashMapByKey() throws SQLException {
+        returnsInOrder("select getByKey(m.this, 'GMT') v from java.util.HashMap m where getSize(m.this) = 208", 
+                       "v",
+                       "Etc/GMT");
+    }
+
+    @Test
+    public void testReferenceResult() throws SQLException {
+        returnsInOrder("select length(getByKey(m.this, 'GMT')['value']) l from java.util.HashMap m where getSize(m.this) = 208",
+                       "l",
+                       "7");
+    }
+
+    //@Test
+    public void testConcurrentHashMap() throws SQLException {
+        returnsInOrder("select getByKey(m.this, 'MST')['ID'] c from java.util.concurrent.ConcurrentHashMap m where getByKey(m.this, 'MST') is not null",
+                       "c",
+                       "MST");
+    }
+}

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/SampleHeapDumpTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/SampleHeapDumpTests.java
@@ -1,0 +1,27 @@
+package com.github.vlsi.mat.tests.calcite;
+
+import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.snapshot.ISnapshot;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.File;
+
+public abstract class SampleHeapDumpTests extends AbstractQueriesTests {
+    protected static ISnapshot snapshot;
+
+    @BeforeClass
+    public static void openSnapshot() throws SnapshotException {
+        snapshot = openSnapshot(new File("dumps", "mvn1m_jdk18.hprof"));
+    }
+
+    @AfterClass
+    public static void closeSnapshot() {
+        closeSnapshot(snapshot);
+        snapshot = null;
+    }
+
+    protected ISnapshot getSnapshot() {
+        return snapshot;
+    }
+}


### PR DESCRIPTION
Check whether result of 'getByKey' function should be treated as HeapReference to allow syntax like 'getByKey(v.mapValue, 'a')['fieldName']' as well as context-menu in output table.