### PR TITLE
Introduce 'asArray' group of functions

### DIFF
--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
@@ -72,9 +72,9 @@ public class CollectionsFunctions extends HeapFunctionsBase {
   }
 
   public static class ArrayFunction extends BaseImplementableFunction {
-    private final Class elementType;
+    private final Class<?> elementType;
 
-    ArrayFunction(Method method, Class elementType) {
+    ArrayFunction(Method method, Class<?> elementType) {
       super(method);
       this.elementType = elementType;
     }
@@ -102,7 +102,7 @@ public class CollectionsFunctions extends HeapFunctionsBase {
   }
 
   @SuppressWarnings("unused")
-  public static Map asMap(Object r) {
+  public static Map<String, Object> asMap(Object r) {
     HeapReference ref = ensureHeapReference(r);
     if (ref == null) {
       return null;
@@ -115,9 +115,8 @@ public class CollectionsFunctions extends HeapFunctionsBase {
       } else {
         Map<String, Object> result = new HashMap<>();
         for (Map.Entry<IObject, IObject> entry : extractedMap) {
-          result.put(
-              toString(entry.getKey()),
-              resolveReference(entry.getValue())
+          result.put(toString(entry.getKey()),
+                     resolveReference(entry.getValue())
                     );
         }
         return result;
@@ -128,7 +127,7 @@ public class CollectionsFunctions extends HeapFunctionsBase {
   }
 
   @SuppressWarnings("unused")
-  public static List asMultiSet(Object r) {
+  public static List<HeapReference> asMultiSet(Object r) {
     HeapReference ref = ensureHeapReference(r);
     if (ref == null) {
       return null;
@@ -151,7 +150,7 @@ public class CollectionsFunctions extends HeapFunctionsBase {
   }
 
   @SuppressWarnings("unused")
-  public static List asArray(Object r) {
+  public static List<?> asArray(Object r) {
     HeapReference ref = ensureHeapReference(r);
     if (ref == null) {
       return null;

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
@@ -18,7 +18,11 @@ import org.eclipse.mat.SnapshotException;
 import org.eclipse.mat.inspections.collectionextract.CollectionExtractionUtils;
 import org.eclipse.mat.inspections.collectionextract.ExtractedCollection;
 import org.eclipse.mat.inspections.collectionextract.ExtractedMap;
+import org.eclipse.mat.snapshot.ISnapshot;
+import org.eclipse.mat.snapshot.model.IArray;
 import org.eclipse.mat.snapshot.model.IObject;
+import org.eclipse.mat.snapshot.model.IObjectArray;
+import org.eclipse.mat.snapshot.model.IPrimitiveArray;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -30,7 +34,7 @@ import java.util.Map;
 public class CollectionsFunctions extends HeapFunctionsBase {
 
   public abstract static class BaseImplementableFunction extends ReflectiveFunctionBase implements ScalarFunction,
-      ImplementableFunction {
+                                                                                                   ImplementableFunction {
     final CallImplementor implementor;
 
     BaseImplementableFunction(Method method) {
@@ -52,7 +56,7 @@ public class CollectionsFunctions extends HeapFunctionsBase {
     @Override
     public RelDataType getReturnType(RelDataTypeFactory relDataTypeFactory) {
       return relDataTypeFactory.createMapType(relDataTypeFactory.createJavaType(String.class),
-          relDataTypeFactory.createJavaType(HeapReference.class));
+                                              relDataTypeFactory.createJavaType(HeapReference.class));
     }
   }
 
@@ -67,10 +71,33 @@ public class CollectionsFunctions extends HeapFunctionsBase {
     }
   }
 
+  public static class ArrayFunction extends BaseImplementableFunction {
+    private final Class elementType;
+
+    ArrayFunction(Method method, Class elementType) {
+      super(method);
+      this.elementType = elementType;
+    }
+
+    @Override
+    public RelDataType getReturnType(RelDataTypeFactory relDataTypeFactory) {
+      return relDataTypeFactory.createArrayType(relDataTypeFactory.createJavaType(elementType), -1);
+    }
+  }
+
   public static Multimap<String, ScalarFunction> createAll() {
     ImmutableMultimap.Builder<String, ScalarFunction> builder = ImmutableMultimap.builder();
     builder.put("asMap", new MapFunction(findMethod(CollectionsFunctions.class, "asMap")));
     builder.put("asMultiSet", new MultiSetFunction(findMethod(CollectionsFunctions.class, "asMultiSet")));
+    builder.put("asArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), HeapReference.class));
+    builder.put("asByteArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Byte.class));
+    builder.put("asShortArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Short.class));
+    builder.put("asIntArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Integer.class));
+    builder.put("asLongArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Long.class));
+    builder.put("asBooleanArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Boolean.class));
+    builder.put("asCharArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Character.class));
+    builder.put("asFloatArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Float.class));
+    builder.put("asDoubleArray", new ArrayFunction(findMethod(CollectionsFunctions.class, "asArray"), Double.class));
     return builder.build();
   }
 
@@ -91,7 +118,7 @@ public class CollectionsFunctions extends HeapFunctionsBase {
           result.put(
               toString(entry.getKey()),
               resolveReference(entry.getValue())
-          );
+                    );
         }
         return result;
       }
@@ -121,6 +148,45 @@ public class CollectionsFunctions extends HeapFunctionsBase {
     } catch (SnapshotException e) {
       throw new RuntimeException("Unable to extract collection from " + r, e);
     }
+  }
 
+  @SuppressWarnings("unused")
+  public static List asArray(Object r) {
+    HeapReference ref = ensureHeapReference(r);
+    if (ref == null) {
+      return null;
+    }
+
+    IObject iObject = ref.getIObject();
+    if (!(iObject instanceof IArray)) {
+      return null;
+    }
+
+    try {
+      if (iObject instanceof IPrimitiveArray) {
+        IPrimitiveArray arrayObject = (IPrimitiveArray) iObject;
+        int length = arrayObject.getLength();
+        List<Object> result = new ArrayList<>(length);
+        for (int i = 0; i < length; i++) {
+          result.add(arrayObject.getValueAt(i));
+        }
+        return result;
+      } else {
+        IObjectArray arrayObject = (IObjectArray) iObject;
+        ISnapshot snapshot = arrayObject.getSnapshot();
+        int length = arrayObject.getLength();
+        List<HeapReference> result = new ArrayList<>(length);
+        for (long objectAddress : arrayObject.getReferenceArray()) {
+          if (objectAddress != 0) {
+            result.add(HeapReference.valueOf(snapshot.getObject(snapshot.mapAddressToId(objectAddress))));
+          } else {
+            result.add(null);
+          }
+        }
+        return result;
+      }
+    } catch (SnapshotException e) {
+      throw new RuntimeException("Unable to extract references from array " + r, e);
+    }
   }
 }

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AllTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/AllTests.java
@@ -7,7 +7,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
     BasicQueriesTests.class,
     GetByKeyTests.class,
-    TableFunctionsTests.class
+    TableFunctionsTests.class,
+    CollectionsFunctionsTests.class
 })
 public class AllTests {
 }

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
@@ -232,21 +232,7 @@ public class BasicQueriesTests extends SampleHeapDumpTests {
         "114976");
   }
 
-  @Test
-  public void selectOutboundReferences() throws SQLException {
-    returnsInOrder("select sum(retainedSize(og.this)) retained_size, count(og.name) cnt_name from java.util.HashMap " +
-            "hm, lateral (select * from table(getOutboundReferences(hm.this))) as og(name, this)",
-        "retained_size|cnt_name",
-        "113712|155");
-  }
 
-  @Test
-  public void selectOutboundReferencesCrossApply() throws SQLException {
-    returnsInOrder("select sum(retainedSize(og.this)) retained_size, count(og.name) cnt_name from java.util.HashMap " +
-            "hm cross apply table(getOutboundReferences(hm.this)) as og(name, this)",
-        "retained_size|cnt_name",
-        "113712|155");
-  }
 
   @Test
   public void testReadme() throws SQLException {
@@ -273,12 +259,5 @@ public class BasicQueriesTests extends SampleHeapDumpTests {
         "   from java.lang.String s\n" +
         "   join java.net.URL u\n" +
         "     on s.this = u.path", 10);
-  }
-
-  @Test
-  public void testAsMap() throws SQLException {
-    returnsInOrder("select getField(asMap(m.this)['org.codehaus.plexus.classworlds'],'pkgName') pkgName from java" +
-            ".util.HashMap m where m.size = 4",
-        "pkgName", "org.codehaus.plexus.classworlds");
   }
 }

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/CollectionsFunctionsTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/CollectionsFunctionsTests.java
@@ -1,0 +1,115 @@
+package com.github.vlsi.mat.tests.calcite;
+
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+public class CollectionsFunctionsTests extends SampleHeapDumpTests {
+  // asMap
+
+  @Test
+  public void testAsMap() throws SQLException {
+    returnsInOrder("select getField(asMap(m.this)['org.codehaus.plexus.classworlds'],'pkgName') pkgName from java" +
+                   ".util.HashMap m where m.size = 4",
+                   "pkgName", "org.codehaus.plexus.classworlds");
+  }
+
+  // asMultiSet
+
+  @Test
+  public void testAsMultiset() throws SQLException {
+    returnsInOrder("select n from (\n" +
+                   "select \n" +
+                   " toString(getField(r.this, 'name')) n\n" +
+                   "from \n" +
+                   " java.util.logging.LogManager lm,\n" +
+                   " unnest(asMultiSet(lm.rootLogger['kids'])) r(this)\n" +
+                   ") order by n",
+                   "n",
+                   "com.google.inject.internal.util.Stopwatch",
+                   "global");
+  }
+
+  // asArray
+
+  @Test
+  public void testAsArray() throws SQLException {
+    returnsInOrder("select \n" +
+                   " g.index,\n" +
+                   " toString(g.threadName) threadName\n" +
+                   "from \n" +
+                   " java.lang.ThreadGroup tg,\n" +
+                   " unnest(asArray(tg.threads)) with ordinality g(threadName, index)\n" +
+                   "where \n" +
+                   " toString(tg.name)='system'",
+                   "index|threadName",
+                   "1|Reference Handler",
+                   "2|Finalizer",
+                   "3|Signal Dispatcher",
+                   "4|null");
+  }
+
+  // asByteArray
+
+  @Test
+  public void testAsByteArray() throws SQLException {
+    returnsInOrder("select asByteArray(ps.\"out\"['buf'])[1] b from java.io.PrintStream ps",
+                   "b", "0", "0");
+  }
+
+  // asShortArray
+  // Test dump has no short[] objects
+//  @Test
+//  public void testAsShortArray() throws SQLException {
+//
+//  }
+
+  // asIntArray
+
+  @Test
+  public void testAsIntArray() throws SQLException {
+    returnsInOrder("select sum(cs.v) s from java.util.GregorianCalendar c, unnest(asIntArray(c.stamp)) cs(v)",
+                   "s", "68");
+  }
+
+  // asLongArray
+
+  @Test
+  public void testAsLongArray() throws SQLException {
+    returnsInOrder("select asLongArray(m.this)[14] c from \"long[]\" m where cardinality(asLongArray(m.this)) = 16",
+                   "c", "1388527200000");
+  }
+
+  // asBooleanArray
+
+  @Test
+  public void testAsBooleanArray() throws SQLException {
+    returnsInOrder("select min(case when v.this then 1 else 0 end) minv, max(case when v.this then 1 else 0 end) maxv" +
+                   " from \"boolean[]\" b, unnest(asBooleanArray(b.this)) v(this)",
+                   "minv|maxv","0|1");
+  }
+
+  // asCharArray
+
+  @Test
+  public void testAsCharArray() throws SQLException {
+    returnsInOrder("select listagg(toString(v.this),'') ns from java.lang.String s, unnest(asCharArray(s.\"value\")) " +
+                   "v(this) where toString(s.this) = 'com.google.common.collect.Maps'",
+                   "ns","com.google.common.collect.Maps");
+  }
+
+  // asFloatArray
+  // Test dump has no float[] objects
+//  @Test
+//  public void testAsFloatArray() throws SQLException {
+//
+//  }
+
+  // asDoubleArray
+  // Test dump has no double[] objects
+//  @Test
+//  public void testAsDoubleArray() throws SQLException {
+//
+//  }
+
+}

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/CollectionsFunctionsTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/CollectionsFunctionsTests.java
@@ -58,11 +58,13 @@ public class CollectionsFunctionsTests extends SampleHeapDumpTests {
   }
 
   // asShortArray
-  // Test dump has no short[] objects
-//  @Test
-//  public void testAsShortArray() throws SQLException {
-//
-//  }
+
+  @Test
+  public void testAsShortArray() throws SQLException {
+    // Test dump has no short[] objects, so we just check that function could be invoked
+    returnsInOrder("select cardinality(asShortArray(o.this)) m from java.lang.Object o limit 1",
+                   "m", "0");
+  }
 
   // asIntArray
 
@@ -99,17 +101,21 @@ public class CollectionsFunctionsTests extends SampleHeapDumpTests {
   }
 
   // asFloatArray
-  // Test dump has no float[] objects
-//  @Test
-//  public void testAsFloatArray() throws SQLException {
-//
-//  }
+
+  @Test
+  public void testAsFloatArray() throws SQLException {
+    // Test dump has no float[] objects, so we just check that function could be invoked
+    returnsInOrder("select cardinality(asFloatArray(o.this)) m from java.lang.Object o limit 1",
+                   "m", "0");
+  }
 
   // asDoubleArray
-  // Test dump has no double[] objects
-//  @Test
-//  public void testAsDoubleArray() throws SQLException {
-//
-//  }
+
+  @Test
+  public void testAsDoubleArray() throws SQLException {
+    // Test dump has no double[] objects, so we just check that function could be invoked
+    returnsInOrder("select cardinality(asDoubleArray(o.this)) m from java.lang.Object o limit 1",
+                   "m", "0");
+  }
 
 }

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/TableFunctionsTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/TableFunctionsTests.java
@@ -10,4 +10,20 @@ public class TableFunctionsTests extends SampleHeapDumpTests {
     returnsInOrder("select count(*) cnt from java.util.HashMap m, lateral table(getMapEntries(m.this)) r where m.size" +
         " = 4", "cnt", "4");
   }
+
+  @Test
+  public void selectOutboundReferences() throws SQLException {
+    returnsInOrder("select sum(retainedSize(og.this)) retained_size, count(og.name) cnt_name from java.util.HashMap " +
+                   "hm, lateral (select * from table(getOutboundReferences(hm.this))) as og(name, this)",
+                   "retained_size|cnt_name",
+                   "113712|155");
+  }
+
+  @Test
+  public void selectOutboundReferencesCrossApply() throws SQLException {
+    returnsInOrder("select sum(retainedSize(og.this)) retained_size, count(og.name) cnt_name from java.util.HashMap " +
+                   "hm cross apply table(getOutboundReferences(hm.this)) as og(name, this)",
+                   "retained_size|cnt_name",
+                   "113712|155");
+  }
 }

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ from
 
     asMap(ref)                 | converts Java Map to SQL MAP, so it can be used like asMap(ref)['key']
     asMultiSet(ref)            | converts Java Collection to SQL MULTISET type
+    asArray(ref)               | converts Java references array to SQL ARRAY type
+    asByteArray(ref)           | converts Java bytes array (bytes[]) to SQL ARRAY type
+    asShortArray(ref)          | converts Java shorts array (short[]) to SQL ARRAY type
+    asIntArray(ref)            | converts Java ints array (int[]) to SQL ARRAY type
+    asLongArray(ref)           | converts Java longs array (long[]) to SQL ARRAY type
+    asBooleanArray(ref)        | converts Java boolean array (boolean[]) to SQL ARRAY type
+    asCharArray(ref)           | converts Java chars array (char[]) to SQL ARRAY type
+    asFloatArray(ref)          | converts Java floats array (float[]) to SQL ARRAY type
+    asDoubleArray(ref)         | converts Java doubles array (double[]) to SQL ARRAY type
 
  These functions can be called in a following way:
 ```sql
@@ -194,6 +203,16 @@ select
 from 
  java.io.FilePermissionCollection fpc,
  unnest(asMultiSet(fpc.perms)) fp(fp_ref)
+```
+
+ Note, that SQL arrays are indexed starting with '1', so following example shows how to get first element of long[] arrays:
+```sql
+select 
+ asLongArray(all_long_arrays.this)[1] first_element
+from 
+ "long[]" all_long_arrays
+where 
+ length(all_long_arrays.this) > 0
 ```
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -214,6 +214,17 @@ from
 where 
  length(all_long_arrays.this) > 0
 ```
+ 
+ Array index could be extracted into the table by using the 'unnest ... with ordinality' clause:
+```sql
+select
+    c.this,
+    cs.index,
+    cs.val
+from
+    java.util.GregorianCalendar c,
+    unnest(asIntArray(c.stamp)) with ordinality cs(val, index)
+```
 
 Requirements
 ------------


### PR DESCRIPTION
Currently there is no way to extract values of primitive arrays, as all table and collection functions assume that content of arrays are references. This PR introduces group of 'asArray' functions ('asArray' for references array and 'asByteArray' / 'asShortArray' / 'asIntArray' / 'asLongArray' / 'asBooleanArray' / 'asCharArray' / 'asFloatArray' / 'asDoubleArray' for arrays with primitive types) which convert Java arrays to SQL ARRAY type, so it can be queried, dumped (using 'toString' function) or unnested (i.e. transformed to table) in the query.