### PR TITLE
Proposed changes for MatCalcitePlugin 1.6.0

### DIFF
--- a/MatCalciteDependencies/pom.xml
+++ b/MatCalciteDependencies/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.1</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <manifestLocation>META-INF</manifestLocation>
@@ -74,7 +74,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.felix</groupId>
                                         <artifactId>maven-bundle-plugin</artifactId>
-                                        <versionRange>5.1.1</versionRange>
+                                        <versionRange>5.1.9</versionRange>
                                         <goals>
                                             <goal>bundle</goal>
                                         </goals>
@@ -89,7 +89,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.felix</groupId>
                                         <artifactId>maven-bundle-plugin</artifactId>
-                                        <versionRange>5.1.1</versionRange>
+                                        <versionRange>5.1.9</versionRange>
                                         <goals>
                                             <goal>manifest</goal>
                                         </goals>

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/CollectionsFunctions.java
@@ -161,31 +161,23 @@ public class CollectionsFunctions extends HeapFunctionsBase {
       return null;
     }
 
-    try {
-      if (iObject instanceof IPrimitiveArray) {
-        IPrimitiveArray arrayObject = (IPrimitiveArray) iObject;
-        int length = arrayObject.getLength();
-        List<Object> result = new ArrayList<>(length);
-        for (int i = 0; i < length; i++) {
-          result.add(arrayObject.getValueAt(i));
-        }
-        return result;
-      } else {
-        IObjectArray arrayObject = (IObjectArray) iObject;
-        ISnapshot snapshot = arrayObject.getSnapshot();
-        int length = arrayObject.getLength();
-        List<HeapReference> result = new ArrayList<>(length);
-        for (long objectAddress : arrayObject.getReferenceArray()) {
-          if (objectAddress != 0) {
-            result.add(HeapReference.valueOf(snapshot.getObject(snapshot.mapAddressToId(objectAddress))));
-          } else {
-            result.add(null);
-          }
-        }
-        return result;
+    if (iObject instanceof IPrimitiveArray) {
+      IPrimitiveArray arrayObject = (IPrimitiveArray) iObject;
+      int length = arrayObject.getLength();
+      List<Object> result = new ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        result.add(arrayObject.getValueAt(i));
       }
-    } catch (SnapshotException e) {
-      throw new RuntimeException("Unable to extract references from array " + r, e);
+      return result;
+    } else {
+      IObjectArray arrayObject = (IObjectArray) iObject;
+      ISnapshot snapshot = arrayObject.getSnapshot();
+      int length = arrayObject.getLength();
+      List<HeapReference> result = new ArrayList<>(length);
+      for (long objectAddress : arrayObject.getReferenceArray()) {
+        result.add(resolveReference(snapshot, objectAddress));
+      }
+      return result;
     }
   }
 }

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
@@ -174,7 +174,7 @@ public class HeapFunctions extends HeapFunctionsBase {
         // Initially such calls were routed to IObject.resolveValue, which accepts field names as '[<index>]' for arrays.
         // However, this have two problems:
         // 1. This doesn't work with primitive arrays (they always return null)
-        // 2. This doesn't correct work with <null> values - MAT code doesn't handle 0 address properly in this case
+        // 2. This doesn't correctly work with <null> values - MAT code doesn't handle 0 address properly in this case
         // So, now we handle this case directly in our code
         int index = Integer.parseInt(fieldName.substring(1, fieldName.length() - 1));
         int length = ((IArray) iObject).getLength();
@@ -182,17 +182,7 @@ public class HeapFunctions extends HeapFunctionsBase {
           if (iObject instanceof IPrimitiveArray) {
             return ((IPrimitiveArray) iObject).getValueAt(index);
           } else if (iObject instanceof IObjectArray) {
-            long objectAddress = ((IObjectArray) iObject).getReferenceArray()[index];
-            if (objectAddress != 0) {
-              ISnapshot snapshot = iObject.getSnapshot();
-              try {
-                return resolveReference(snapshot.getObject(snapshot.mapAddressToId(objectAddress)));
-              } catch (SnapshotException e) {
-                return null;
-              }
-            } else {
-              return null;
-            }
+            return resolveReference(iObject.getSnapshot(), ((IObjectArray) iObject).getReferenceArray()[index]);
           }
         } else {
           return null;
@@ -256,7 +246,6 @@ public class HeapFunctions extends HeapFunctionsBase {
     } catch (SnapshotException e) {
       throw new RuntimeException("Cannot obtain immediate dominator object for " + r, e);
     }
-
   }
 
 }

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctions.java
@@ -205,6 +205,30 @@ public class HeapFunctions extends HeapFunctionsBase {
   }
 
   @SuppressWarnings("unused")
+  public static Object getStaticField(Object r, String name) {
+    HeapReference ref = ensureHeapReference(r);
+    if (ref == null) {
+      return null;
+    }
+
+    IObject iObject = ref.getIObject();
+    if (iObject instanceof IClass) {
+      IClass iClass = (IClass) iObject;
+      for (Field field : iClass.getStaticFields()) {
+        if (field.getName().equals(name)) {
+          Object value = field.getValue();
+          if (value instanceof IObject) {
+            return new HeapReference((IObject) value);
+          } else {
+            return value;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unused")
   public static long getAddress(Object r) {
     HeapReference ref = ensureHeapReference(r);
     if (ref == null) {

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctionsBase.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/HeapFunctionsBase.java
@@ -2,6 +2,8 @@ package com.github.vlsi.mat.calcite.functions;
 
 import com.github.vlsi.mat.calcite.HeapReference;
 
+import org.eclipse.mat.SnapshotException;
+import org.eclipse.mat.snapshot.ISnapshot;
 import org.eclipse.mat.snapshot.model.IObject;
 
 import java.lang.reflect.Method;
@@ -9,6 +11,18 @@ import java.lang.reflect.Method;
 public class HeapFunctionsBase {
   protected static Object resolveReference(Object value) {
     return value instanceof IObject ? HeapReference.valueOf((IObject) value) : value;
+  }
+
+  protected static HeapReference resolveReference(ISnapshot snapshot, long address) {
+    if (address == 0) {
+      // Eclipse MAT always returns "SystemClassLoader" for address=0, so we return null instead
+      return null;
+    }
+    try {
+      return HeapReference.valueOf(snapshot.getObject(snapshot.mapAddressToId(address)));
+    } catch (SnapshotException e) {
+      return null;
+    }
   }
 
   protected static HeapReference ensureHeapReference(Object r) {

--- a/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/SnapshotFunctions.java
+++ b/MatCalcitePlugin/src/com/github/vlsi/mat/calcite/functions/SnapshotFunctions.java
@@ -20,7 +20,6 @@ import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.schema.ImplementableFunction;
 import org.apache.calcite.schema.ScalarFunction;
 import org.apache.calcite.schema.impl.ReflectiveFunctionBase;
-import org.eclipse.mat.SnapshotException;
 import org.eclipse.mat.snapshot.ISnapshot;
 
 import java.lang.reflect.Constructor;
@@ -36,11 +35,7 @@ public class SnapshotFunctions {
 
   @SuppressWarnings("unused")
   public HeapReference getReference(String address) {
-    try {
-      return HeapReference.valueOf(snapshot.getObject(snapshot.mapAddressToId(Long.decode(address))));
-    } catch (SnapshotException e) {
-      throw new RuntimeException("Cannot get object by address '" + address + "'", e);
-    }
+    return HeapFunctionsBase.resolveReference(snapshot, Long.decode(address));
   }
 
   public static Multimap<String, Function> createAll(ISnapshot snapshot) {
@@ -49,11 +44,11 @@ public class SnapshotFunctions {
     return builder.build();
   }
 
-  private static Function getFunction(ISnapshot snapshot, String name, Class... argumentClasses) {
+  private static Function getFunction(ISnapshot snapshot, String name, Class<?> ... argumentClasses) {
     return new SnapshotFunction(snapshot, getMethod(SnapshotFunctions.class, name, argumentClasses));
   }
 
-  private static Method getMethod(Class<?> cls, String name, Class... argumentClasses) {
+  private static Method getMethod(Class<?> cls, String name, Class<?> ... argumentClasses) {
     try {
       return cls.getMethod(name, argumentClasses);
     } catch (NoSuchMethodException e) {
@@ -61,7 +56,7 @@ public class SnapshotFunctions {
     }
   }
 
-  private static <T> Constructor<T> getConstructor(Class<T> cls, Class... argumentClasses) {
+  private static <T> Constructor<T> getConstructor(Class<T> cls, Class<?> ... argumentClasses) {
     try {
       return cls.getConstructor(argumentClasses);
     } catch (NoSuchMethodException e) {

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
@@ -208,7 +208,7 @@ public class BasicQueriesTests extends SampleHeapDumpTests {
   public void selectThisMapField() throws SQLException {
     returnsInOrder("select count(this['table'][0]) count_first_entry from java.util.HashMap",
         "count_first_entry",
-        "71");
+        "18");
   }
 
   @Test

--- a/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
+++ b/MatCalciteTest/src/com/github/vlsi/mat/tests/calcite/BasicQueriesTests.java
@@ -216,6 +216,10 @@ public class BasicQueriesTests extends SampleHeapDumpTests {
     returnsInOrder("select count(this['table.[0]']) count_first_entry from java.util.HashMap",
         "count_first_entry",
         "71");
+    // This is actually incorrect, as IObject.resolveValue handle null values in array as reference to first Object on
+    // heap (i.e. System ClassLoader). The previous test (@selectThisMapField) handles null values correctly (as we
+    // do it directly in our code), so the correct result should be 18, but as we testing Mat syntax here (handled by
+    // Mat itself), so we just accept its behavior.
   }
 
   @Test
@@ -232,7 +236,19 @@ public class BasicQueriesTests extends SampleHeapDumpTests {
         "114976");
   }
 
+  @Test
+  public void testGetField() throws SQLException {
+    returnsInOrder("select getField(lm.this, 'initializationDone') a, getField(lm.rootLogger, 'levelValue') b, getField(lm.this, 'listenerMap')['size'] c from java.util.logging.LogManager lm",
+                   "a|b|c",
+                   "true|800|0");
+  }
 
+  @Test
+  public void testGetStaticField() throws SQLException {
+    returnsInOrder("select c.name, getStaticField(c.this, 'serialVersionUID') serialVersionUID from java.lang.Class c where c.name = 'java.util.HashMap'",
+                   "name|serialVersionUID",
+                   "java.util.HashMap|362498820763181265");
+  }
 
   @Test
   public void testReadme() throws SQLException {

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Heap schema
     getSize      | size of referenced collection, map or count of non-null elements in array
     getByKey     | extracts value for given string representation of key for referenced map
     getField     | obtains value of field with specified name for referenced object
+    getStaticField   | obtains value of static field with specified name for referenced class
     getStringContent | pretty prints object representation
 
  The following table functions are supported:


### PR DESCRIPTION
Changes:
1. Handle '[<index>]' field name references directly in our code for arrays, instead of delegating work to IObject.resolveValue. This solves two problems: a) IObject.resolveValue('[..]') doesn't work with arrays of primitive values and b) IObject.resolveValue doesn't work well with null values.
2. Introduce the 'getStaticField' function, which obtains value of a static field with the specified name for the referenced class.
3. Update maven-bundle-plugin to 5.1.9 version to solve problem with 'ZipException : Invalid CEN header (invalid zip64 extra data field size)' error for MatCalciteDependencies.jar on Java 17.0.8.
